### PR TITLE
Fix SFML linker errors in Release build

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -2,9 +2,9 @@ name: MSBuild
 
 on:
   push:
-    branches: #[ "master" ]
+    branches: [ "master" ]
   pull_request:
-    branches: #[ "master" ]
+    branches: [ "master" ]
   workflow_dispatch: 
 
 env:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -2,9 +2,9 @@ name: MSBuild
 
 on:
   push:
-    branches: [ "master" ]
+    branches: #[ "master" ]
   pull_request:
-    branches: [ "master" ]
+    branches: #[ "master" ]
   workflow_dispatch: 
 
 env:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,48 @@
+name: MSBuild
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch: 
+
+env:
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: SpaDomacaZadaca01.sln
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Release, Debug]
+        platform: [x64]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Add MSBuild to PATH (VS 2017)
+      uses: microsoft/setup-msbuild@v1.0.2
+      with:
+        vs-version: '15.9'
+
+    - name: Restore NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      
+      run: msbuild /m /p:Configuration=${{matrix.build_type}} /p:Platform=${{matrix.platform}} ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with: 
+        name: windows-${{matrix.platform}}-${{matrix.build_type}}-artifact
+        path: '**/${{matrix.platform}}/${{matrix.build_type}}/**'

--- a/SpaDomacaZadaca01/SpaDomacaZadaca01.vcxproj
+++ b/SpaDomacaZadaca01/SpaDomacaZadaca01.vcxproj
@@ -131,7 +131,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>D:\Temp\SPA DZ01 SFML\SFML-2.4.2\lib</AdditionalLibraryDirectories>
-      <AdditionalDependencies>opengl32.lib; freetype.lib; jpeg.lib; winmm.lib; sfml-graphics-s-d.lib; sfml-window-s-d.lib; sfml-system-s-d.lib; kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opengl32.lib; freetype.lib; jpeg.lib; winmm.lib; sfml-graphics-s.lib; sfml-window-s.lib; sfml-system-s.lib; kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -151,7 +151,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>..\SFML-2.5.1\lib</AdditionalLibraryDirectories>
-      <AdditionalDependencies>opengl32.lib; freetype.lib; winmm.lib; sfml-graphics-s-d.lib; sfml-window-s-d.lib; sfml-system-s-d.lib; kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opengl32.lib; freetype.lib; winmm.lib; sfml-graphics-s.lib; sfml-window-s.lib; sfml-system-s.lib; kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Mirror of [this pull](https://github.com/gdambic/gdambic-rvs19-spa-dz-02/pull/38) for this repo, with an added GitHub action that validates both Debug and Release builds on x64 and uploads artifacts for testing. Light testing is advised, but this should basically be good right away.